### PR TITLE
fix: OpenGL depth buffer handling on Linux/macOS

### DIFF
--- a/Singularity/Shaders/SingularityShaders/Assets/Shaders/BlackHoleAccretionDisk.shader
+++ b/Singularity/Shaders/SingularityShaders/Assets/Shaders/BlackHoleAccretionDisk.shader
@@ -209,7 +209,13 @@
 
 				screenColor = tex2D(SingularityScreenBuffer,screenPos.xy);
 
+				// On D3D (reversed-Z): depth=1 at near, 0 at far. Convert via (1-depth) before remapping to [-1,1] for GL-convention unity_CameraInvProjection.
+				// On OpenGL (non-reversed-Z): depth=0 at near, 1 at far. Use depth directly before remapping to [-1,1].
+			#if defined(UNITY_REVERSED_Z)
 				float4 depthClipPos = float4(screenPos.xy, 1.0-depth, 1.0);
+			#else
+				float4 depthClipPos = float4(screenPos.xy, depth, 1.0);
+			#endif
 				depthClipPos.xyz = 2.0f * depthClipPos.xyz - 1.0f;
 
 				//position of the fragment we are getting from the screen texture
@@ -327,10 +333,18 @@
 						onScreen = onScreenBuffer(infinityPos, blackHoleOrigin, depth, screenColor);
 					}
 
+					// On reversed-Z (D3D/Metal): cleared/sky depth = 0.0, actual objects have depth > 0.0
+					// On non-reversed-Z (OpenGL): cleared/sky depth = 1.0, actual objects have depth < 1.0
+					#if defined(UNITY_REVERSED_Z)
+						bool depthHasObject = depth > 0.0;
+					#else
+						bool depthHasObject = depth < 1.0;
+					#endif
+
 					if (length(_WorldSpaceCameraPos.xyz-blackHoleOrigin) > 4 * blackHoleRadius)
 					{
 						// on screen -> use screenColor if actually an object or galaxyColor, object off screen -> use objectCubeMapColor if actually an object or galaxyColor
-						screenColor = onScreen ? ( depth > 0.0 ? screenColor : galaxyCubeMapColor ) : ( onObjectCubeMap ? objectCubeMapColor.rgb : galaxyCubeMapColor);
+						screenColor = onScreen ? ( depthHasObject ? screenColor : galaxyCubeMapColor ) : ( onObjectCubeMap ? objectCubeMapColor.rgb : galaxyCubeMapColor);
 					}
 					else
 					{

--- a/Singularity/Shaders/SingularityShaders/Assets/Shaders/CopyCameraDepth.shader
+++ b/Singularity/Shaders/SingularityShaders/Assets/Shaders/CopyCameraDepth.shader
@@ -31,7 +31,7 @@
 
 			float frag(v2f IN) : SV_Depth
 			{
-				return float4(tex2Dlod(_CameraDepthTexture, float4(IN.uv,0.0,0.0)).rgb,1.0);
+				return tex2Dlod(_CameraDepthTexture, float4(IN.uv,0.0,0.0)).r;
 			}
 			ENDCG
 		}
@@ -65,7 +65,7 @@
 
 			float frag(v2f IN) : SV_Depth
 			{
-				return float4(tex2Dlod(_MainTex, float4(IN.uv,0.0,0.0)).rgb,1.0);
+				return tex2Dlod(_MainTex, float4(IN.uv,0.0,0.0)).r;
 			}
 			ENDCG
 		} 


### PR DESCRIPTION
Hi!

First off, a big thank you for your contributions to KSP. Given the disaster that was KSP2, I find that mods such as this one, Kcalbeloh System and so many others are the true sequel to KSP. As such I want to help and contribute a small bug fix for Singularity:

### Bug

"Hall of mirrors" / screen corruption when looking away from a black hole while inside its lensing radius, on Linux and macOS.

Related: #12, [Kcalbeloh-System#15](https://github.com/jcyuan06/Kcalbeloh-System/issues/15), [Kcalbeloh-System#41](https://github.com/jcyuan06/Kcalbeloh-System/issues/41)

### Root Cause

The shaders assume reversed-Z depth (near=1, far=0), which is true on D3D but not on OpenGL (Linux/macOS), where it's standard-Z (near=0, far=1). Three things break because of this:

1. **Depth reconstruction is inverted**: `onScreenBuffer()` does `1.0 - depth` to get clip-space Z, which flips it the wrong way on OpenGL and gives garbage world positions
2. **Sky is never detected**: the check `depth > 0.0` is always true on OpenGL since sky depth is 1.0, not 0.0, so the galaxy cubemap fallback never kicks in
3. **Wrong return type in CopyCameraDepth**: returns `float4` from a `float : SV_Depth` function. D3D silently takes `.x`, but GLSL is stricter and this can corrupt the copied depth values

Ref: [Unity Platform-specific rendering differences](https://docs.unity3d.com/Manual/SL-PlatformDifferences.html)

### Changes

**BlackHoleAccretionDisk.shader:**
- Wrap depth reconstruction in `#if defined(UNITY_REVERSED_Z)`: use `1.0 - depth` on reversed-Z, `depth` directly on standard-Z
- Wrap sky detection the same way: `depth > 0.0` on reversed-Z, `depth < 1.0` on standard-Z

**CopyCameraDepth.shader:**
- Return `.r` instead of `float4` to match the `float : SV_Depth` declaration

D3D (Windows) paths are untouched, the fix only adds the missing OpenGL path.

### Testing

Tested on macOS with Kcalbeloh System:
- Haven't noticed any regression; accretion disk renders correctly and lensing works correctly when facing the black hole
- No more hall-of-mirrors, orbital lines and such artifacts when looking away
- Skybox shows up properly instead of screen corruption
- Checked all affected planets from tracking station and in vessel view, some of which I show in the fix demonstration video 

Haven't been able to test on Linux, but both platforms use the same OpenGL code path and `UNITY_REVERSED_Z` is undefined on both, so the compiled shader is identical.

#### Video recordings

https://github.com/user-attachments/assets/70df1e62-b6fb-44b1-9cd3-3a69fb44a363


https://github.com/user-attachments/assets/21459be2-81d5-4597-8c51-00c951dbb64c

